### PR TITLE
Add support for  Globals.Function.CodeUri

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,12 @@ class AwsSamPlugin {
       this.samConfig.Globals.Function.Handler
         ? this.samConfig.Globals.Function.Handler
         : null;
+    const defaultCodeUri =
+        this.samConfig.Globals &&
+        this.samConfig.Globals.Function &&
+        this.samConfig.Globals.Function.CodeUri
+          ? this.samConfig.Globals.Function.CodeUri
+          : null;    
 
     const entryPoints: { [pname: string]: string } = {};
 
@@ -84,12 +90,13 @@ class AwsSamPlugin {
             `${resourceKey} Handler must contain exactly one "."`
           );
         }
-
-        if (!properties.CodeUri) {
+        
+        if (!properties.CodeUri || defaultCodeUri) {
           throw new Error(`${resourceKey} is missing a CodeUri`);
         }
+        const codeUri = (properties.CodeUri || defaultCodeUri);
 
-        const basePath = properties.CodeUri ? `./${properties.CodeUri}` : ".";
+        const basePath = codeUri ? `./${codeUri}` : ".";
         const fileBase = `${basePath}/${handler[0]}`;
         for (const ext of [".ts", ".js"]) {
           if (fs.existsSync(`${fileBase}${ext}`)) {


### PR DESCRIPTION
# Now you can share the CodeUri from from Globals.Function

Before this fix you must set a` CodeUri` property for each `Function`.

According to [AWS SAM Globals Reference](https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst) you can set up a common folder for all your handlers.
```yaml
Globals:
  Function:
    CodeUri: src

Resources:

  FunctionA:
    Type: AWS::Serverless::Function
    Properties:
       Handler: fileA.handler #expected path src/fileA.js -> handler function

  FunctionB:
    Type: AWS::Serverless::Function
    Properties:
       Handler: fileB.handler #expected path src/fileB.js -> handler function

  FunctionC:
    Type: AWS::Serverless::Function
    Properties:
       CodeUri: another #Is override-able 
       Handler: fileC.handler #expected path another/fileC.js -> handler function
```

PS: @buggy you saved my life with this plugin for SAM